### PR TITLE
Individual try except in create_bio_labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,5 @@ If you use this dataset, please cite the following paper:
 }
 ```
 URL: https://www.aclweb.org/anthology/2020.lrec-1.618/
+
+

--- a/convert_to_bio.py
+++ b/convert_to_bio.py
@@ -179,7 +179,13 @@ def create_bio_labels(text, opinions):
     for o in opinions:
         try:
             anns["holder"].extend(get_bio_holder(o))
+        except:
+            pass
+        try:
             anns["target"].extend(get_bio_target(o))
+        except:
+            pass
+        try:
             anns["expression"].extend(get_bio_expression(o))
         except:
             pass

--- a/convert_to_bio.py
+++ b/convert_to_bio.py
@@ -1,6 +1,7 @@
 import json
 import nltk
 import re
+import os
 import argparse
 from nltk.tokenize.simple import SpaceTokenizer
 
@@ -212,9 +213,11 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     columns = ["holder", "target", "expression"]
+    if not os.path.exists("data"):
+        os.makedirs("data")
 
     for split in ["train", "dev", "test"]:
-        with open("data/{0}.json".format(split)) as o:
+        with open("{0}.json".format(split)) as o:
             dev = json.load(o)
 
         tokenized, labels = to_bio(dev)


### PR DESCRIPTION
**commit "data folder"** reads json from the same folder as python script, creates "/data" and places conll files there.

**commit "individual try except in convert_to_bio"** creates individual try except for collecting results from `get_bio_holder, get_bio_target and get_bio_expression`.  This allows for reading subsequent info even when previous try failed.

With this script for each file in the data folder, where all three categories are created individually:
```
        text = rf.read()
        for cat in ["exp", "holder", "targ"]:
            if cat in filename:
                print(filename, text.count(f"B-{cat}"))
```

**Counts before modification:**
```
dev_expression.conll 110
dev_holder.conll 90
dev_target.conll 81
test_expression.conll 96
test_holder.conll 74
test_target.conll 70
train_expression.conll 754
train_holder.conll 594
train_target.conll 555
```

**Counts after modification:**
```
dev_expression.conll 1416
dev_holder.conll 90
dev_target.conll 877
test_expression.conll 1224
test_holder.conll 74
test_target.conll 735
train_expression.conll 8234
train_holder.conll 594
train_target.conll 5044
```
These latter are close to the counts in the norec_fine readme.








